### PR TITLE
绘图线条采用深颜色

### DIFF
--- a/rrd/static/js/screen.js
+++ b/rrd/static/js/screen.js
@@ -234,6 +234,28 @@ $(function() {
             series: {
                 shadowSize: 0   // Drawing is faster without shadows
             },
+            // 使用深色色彩可选值, 避免因为绘图线条颜色太浅看不清楚
+            colors:  [
+                "#FF6A6A", "#00BFFF", "#A52A2A",
+                "#CDCD00", "#008878", "#FF0000",
+                "#00FF00", "#7B68EE", "#FF00FF",
+                "#EEAEEE", "#00AEEE", "#AEEEEE",
+
+                "#FFB90F", "#00B90F", "#00FFFF",
+                "#DC143C", "#BFEFFF", "#AA7500",
+                "#F0E68C", "#00E68C", "#AAE68C",
+                "#EE9A49", "#009A49", "#AA9A49",
+
+                "#FFA54F", "#00A54F", "#AAA54F",
+                "#8B4789", "#004789", "#AA4789",
+                "#00CDCD", "#00CDCD", "#AACDCD",
+                "#EE8262", "#008262", "#AA8262",
+
+                "#FF8C00", "#008C00", "#AA8C00",
+                "#8B3626", "#003626", "#AA3626",
+                "#00BFFF", "#00E8AA", "#AAE8AA",
+                "#EE7621", "#007621", "#AA7621",
+                ],
             yaxis: {
                 // min: -1
                 // max: 100

--- a/rrd/static/js/util_ng.js
+++ b/rrd/static/js/util_ng.js
@@ -184,6 +184,28 @@ function FlotServ($http, $window, $q) {
     self.getConfig = function(options) {
         return {
             stack: options.stack || false,
+            // 使用深色色彩可选值, 避免因为绘图线条颜色太浅看不清楚
+            colors:  [
+                "#FF6A6A", "#00BFFF", "#A52A2A",
+                "#CDCD00", "#008878", "#FF0000",
+                "#00FF00", "#7B68EE", "#FF00FF",
+                "#EEAEEE", "#00AEEE", "#AEEEEE",
+
+                "#FFB90F", "#00B90F", "#00FFFF",
+                "#DC143C", "#BFEFFF", "#AA7500",
+                "#F0E68C", "#00E68C", "#AAE68C",
+                "#EE9A49", "#009A49", "#AA9A49",
+
+                "#FFA54F", "#00A54F", "#AAA54F",
+                "#8B4789", "#004789", "#AA4789",
+                "#00CDCD", "#00CDCD", "#AACDCD",
+                "#EE8262", "#008262", "#AA8262",
+
+                "#FF8C00", "#008C00", "#AA8C00",
+                "#8B3626", "#003626", "#AA3626",
+                "#00BFFF", "#00E8AA", "#AAE8AA",
+                "#EE7621", "#007621", "#AA7621",
+                ],
             lines: {
                 show: true
             },


### PR DESCRIPTION
flot绘图组件默认的色彩方案偏暗，造成部分绘图的线条不明显，影响使用。增加了一组自定义的色彩方案，颜色加深。

![qq20160121-0 2x](https://cloud.githubusercontent.com/assets/1411244/12474217/55527690-c054-11e5-9675-eda08ed67502.png)
