### PR TITLE
TLS support for ldap login

### DIFF
--- a/rrd/config.py
+++ b/rrd/config.py
@@ -1,6 +1,7 @@
 #-*-coding:utf8-*-
 # app config
 LOG_LEVEL = 'DEBUG'
+LOG_FILE = '/var/log/falcon-dashboard.log'
 SECRET_KEY = "secret-key"
 PERMANENT_SESSION_LIFETIME = 3600 * 24 * 30
 SITE_COOKIE = "open-falcon-ck"
@@ -30,7 +31,14 @@ LDAP_SERVER = "ldap.forumsys.com:389"
 LDAP_BASE_DN = "dc=example,dc=com"
 LDAP_BINDDN_FMT = "uid=%s,dc=example,dc=com"
 LDAP_SEARCH_FMT = "uid=%s"
-LDAP_ATTRS = ["cn","mail","telephoneNumber"]
+LDAP_ATTRS = ["cn","mail","telephoneNumber", "sn", "givenName", "displayName"]
+LDAP_TLS_START_TLS = False
+LDAP_TLS_CACERTDIR = ""
+LDAP_TLS_CACERTFILE = "/etc/openldap/certs/ca.crt"
+LDAP_TLS_CERTFILE = ""
+LDAP_TLS_KEYFILE = ""
+LDAP_TLS_REQUIRE_CERT = True
+LDAP_TLS_CIPHER_SUITE = ""
 
 # portal site config
 MAINTAINERS = ['root']

--- a/rrd/utils/logger.py
+++ b/rrd/utils/logger.py
@@ -1,8 +1,10 @@
 #-*- coding:utf-8 -*-
 from rrd import config
 import logging
-logging.basicConfig(
-        format='%(asctime)s %(levelname)s:%(message)s',
-        datefmt="%Y-%m-%d %H:%M:%S",
-        level=config.LOG_LEVEL)
+
+logging.basicConfig(level=config.LOG_LEVEL,
+        format='%(asctime)s %(filename)s[%(lineno)d] [%(levelname)s]: %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        filename=config.LOG_FILE,
+        filemode='a+')
 

--- a/rrd/view/utils.py
+++ b/rrd/view/utils.py
@@ -119,15 +119,31 @@ def ldap_login_user(name, password):
 
     cli = None
     try:
-        ldap_server = config.LDAP_SERVER if config.LDAP_SERVER.startswith("ldap://") else "ldap://%s" %config.LDAP_SERVER
-        log.debug("bind_dn=%s base_dn=%s filter=%s attrs=%s" %(bind_dn, config.LDAP_BASE_DN, search_filter, config.LDAP_ATTRS))
+        ldap_server = config.LDAP_SERVER if (config.LDAP_SERVER.startswith("ldap://") or config.LDAP_SERVER.startswith("ldaps://")) else "ldaps://%s" % config.LDAP_SERVER if config.LDAP_TLS_START_TLS else "ldap://%s" % config.LDAP_SERVER
+        log.debug("ldap_server:%s bind_dn:%s base_dn:%s filter:%s attrs:%s" %(ldap_server, bind_dn, config.LDAP_BASE_DN, search_filter, config.LDAP_ATTRS))
         cli = ldap.initialize(ldap_server)
-        cli.bind_s(bind_dn, password)
-        result = cli.search_s(config.LDAP_BASE_DN, ldap.SCOPE_SUBTREE, search_filter, config.LDAP_ATTRS)
+        cli.protocol_version = ldap.VERSION3
+        if config.LDAP_TLS_START_TLS or ldap_server.startswith('ldaps://'):
+            if config.LDAP_TLS_CACERTFILE:
+                cli.set_option(ldap.OPT_X_TLS_CACERTFILE, config.LDAP_TLS_CACERTFILE)
+            if config.LDAP_TLS_CERTFILE:
+                cli.set_option(ldap.OPT_X_TLS_CERTFILE, config.LDAP_TLS_CERTFILE)
+            if config.LDAP_TLS_KEYFILE:
+                cli.set_option(ldap.OPT_X_TLS_KEYFILE, config.LDAP_TLS_KEYFILE)
+            if config.LDAP_TLS_REQUIRE_CERT:
+                cli.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, config.LDAP_TLS_REQUIRE_CERT)
+            if config.LDAP_TLS_CIPHER_SUITE:
+                cli.set_option(ldap.OPT_X_TLS_CIPHER_SUITE, config.LDAP_TLS_CIPHER_SUITE)
+        cli.simple_bind_s(bind_dn, password)
+        result = cli.search_s(bind_dn, ldap.SCOPE_SUBTREE, search_filter, config.LDAP_ATTRS)
         log.debug("ldap result: %s" % result)
         d = result[0][1]
         email = d['mail'][0]
         cnname = d['cn'][0]
+        if 'sn' in d and 'givenName' in d:
+            cnname = d['sn'][0] + d['givenName'][0]
+        if 'displayName' in d:
+            cnname = d['displayName'][0]
         if 'telephoneNumber' in d:
             phone = d['telephoneNumber'] and d['telephoneNumber'][0] or ""
         else:

--- a/rrd/view/utils.py
+++ b/rrd/view/utils.py
@@ -141,7 +141,7 @@ def ldap_login_user(name, password):
         email = d['mail'][0]
         cnname = d['cn'][0]
         if 'sn' in d and 'givenName' in d:
-            cnname = d['sn'][0] + d['givenName'][0]
+            cnname = d['givenName'][0] + ' ' + d['sn'][0]
         if 'displayName' in d:
             cnname = d['displayName'][0]
         if 'telephoneNumber' in d:


### PR DESCRIPTION
1. add log file path setting
2. if LDAP_ATTRS add ["sn", "givenName", "displayName"]
  > sn: last name
  > givenName: first name
  > displayName: maybe can used for chinese name
3. add support TLS, example configure: rrd/local_config.py
```
LOG_LEVEL = 'DEBUG'
LOG_FILE = '/var/log/falcon-dashboard.log'

LDAP_ENABLED = True
LDAP_SERVER = "ldaps://slave.ldap.example.com"
LDAP_TLS_START_TLS = True
LDAP_TLS_CACERTDIR = "/etc/ssl/certs"
LDAP_TLS_CACERTFILE = "/etc/openldap/certs/ca.crt"
LDAP_TLS_CERTFILE = ""
LDAP_TLS_KEYFILE = ""
LDAP_TLS_REQUIRE_CERT = True
LDAP_TLS_CIPHER_SUITE = "TLSv1.2+RSA:!EXPORT:!NULL"
LDAP_BASE_DN = "ou=People,dc=example,dc=com"
LDAP_BINDDN_FMT = "uid=%s,ou=People,dc=example,dc=com"
LDAP_SEARCH_FMT = "(&(objectClass=shadowAccount)(uid=%s))"
#LDAP_SEARCH_FMT = "uid=%s"
LDAP_ATTRS = ["cn","mail", "mobile", "sn", "givenName", "displayName"]
```