### PR TITLE
TLS support for ldap login

### DIFF
--- a/rrd/config.py
+++ b/rrd/config.py
@@ -31,6 +31,13 @@ LDAP_BASE_DN = "dc=example,dc=com"
 LDAP_BINDDN_FMT = "uid=%s,dc=example,dc=com"
 LDAP_SEARCH_FMT = "uid=%s"
 LDAP_ATTRS = ["cn","mail","telephoneNumber"]
+LDAP_TLS_START_TLS = False
+LDAP_TLS_CACERTDIR = ""
+LDAP_TLS_CACERTFILE = "/etc/openldap/certs/ca.crt"
+LDAP_TLS_CERTFILE = ""
+LDAP_TLS_KEYFILE = ""
+LDAP_TLS_REQUIRE_CERT = True
+LDAP_TLS_CIPHER_SUITE = ""
 
 # portal site config
 MAINTAINERS = ['root']


### PR DESCRIPTION
1. LDAP_ATTRS can add ["sn", "givenName", "displayName"]

  > sn: last name
  > givenName: first name
  > displayName: maybe can used for chinese name

2. ldap login support TLS, example configure: `rrd/local_config.py`
```
LDAP_ENABLED = True
LDAP_SERVER = "ldaps://slave.ldap.example.com"
LDAP_TLS_START_TLS = True
LDAP_TLS_CACERTDIR = "/etc/ssl/certs"
LDAP_TLS_CACERTFILE = "/etc/openldap/certs/ca.crt"
LDAP_TLS_CERTFILE = ""
LDAP_TLS_KEYFILE = ""
LDAP_TLS_REQUIRE_CERT = True
LDAP_TLS_CIPHER_SUITE = "TLSv1.2+RSA:!EXPORT:!NULL"
LDAP_BASE_DN = "ou=People,dc=example,dc=com"
LDAP_BINDDN_FMT = "uid=%s,ou=People,dc=example,dc=com"
LDAP_SEARCH_FMT = "(&(objectClass=shadowAccount)(uid=%s))"
LDAP_ATTRS = ["cn","mail", "mobile", "sn", "givenName", "displayName"]
```

3. In this file: `rrd/view/utils.py`

```
result = cli.search_s(config.LDAP_BASE_DN, ldap.SCOPE_SUBTREE, search_filter, config.LDAP_ATTRS)
```

changed to:

```
result = cli.search_s(bind_dn, ldap.SCOPE_SUBTREE, search_filter, config.LDAP_ATTRS)
```

Because if ldap server set an ACL, user can only read it's own node, sldap.conf  ACL configure such as:
```
access to *
        by anonymous auth
        by dn.exact="uid=ldap_read,ou=ldap,dc=example,dc=com" read
        by dn.exact="uid=ldap_write,ou=ldap,dc=example,dc=com" write
        by dn.exact="uid=ldap_admin,ou=ldap,dc=example,dc=com" manage
        by dn.exact="uid=ldap_sync,ou=ldap,dc=example,dc=com" read
        by self read
        by * none
```