### PR TITLE
Add Dockerfile for open-falcon dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM centos:7.3.1611
+
+RUN yum clean all && yum install -y epel-release && yum -y update && \
+yum install -y git python-virtualenv python-devel openldap-devel mysql-devel && \
+yum groupinstall -y "Development tools"
+
+RUN export HOME=/home/work/ && mkdir -p $HOME/open-falcon/dashboard && cd $HOME/open-falcon/dashboard
+WORKDIR /home/work/open-falcon/dashboard
+ADD ./ ./
+RUN virtualenv ./env && ./env/bin/pip install -r pip_requirements.txt -i http://pypi.douban.com/simple
+
+ADD ./entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash 
+# ***********************************************
+# 
+#       Filename: entrypoint.sh
+# 
+#         Author: xwisen 1031649164@qq.com
+#    Description: ---
+#         Create: 2017-05-02 17:43:08
+#  Last Modified: 2017-05-02 17:43:08
+# ***********************************************
+
+./env/bin/python wsgi.py
+

--- a/rrd/config.py
+++ b/rrd/config.py
@@ -1,35 +1,36 @@
 #-*-coding:utf8-*-
 # app config
-LOG_LEVEL = 'DEBUG'
-SECRET_KEY = "secret-key"
-PERMANENT_SESSION_LIFETIME = 3600 * 24 * 30
-SITE_COOKIE = "open-falcon-ck"
+import os
+LOG_LEVEL = os.environ.get("LOG_LEVEL",'DEBUG')
+SECRET_KEY = os.environ.get("SECRET_KEY","secret-key")
+PERMANENT_SESSION_LIFETIME = os.environ.get("PERMANENT_SESSION_LIFETIME",3600 * 24 * 30)
+SITE_COOKIE = os.environ.get("SITE_COOKIE","open-falcon-ck")
 
 # Falcon+ API
-API_ADDR = "http://127.0.0.1:8080/api/v1"
+API_ADDR = os.environ.get("API_ADDR","http://127.0.0.1:8080/api/v1")
 
 # portal database
 # TODO: read from api instead of db
-PORTAL_DB_HOST = "127.0.0.1"
-PORTAL_DB_PORT = 3306
-PORTAL_DB_USER = "root"
-PORTAL_DB_PASS = ""
-PORTAL_DB_NAME = "falcon_portal"
+PORTAL_DB_HOST = os.environ.get("PORTAL_DB_HOST","127.0.0.1")
+PORTAL_DB_PORT = int(os.environ.get("PORTAL_DB_PORT",3306))
+PORTAL_DB_USER = os.environ.get("PORTAL_DB_USER","root")
+PORTAL_DB_PASS = os.environ.get("PORTAL_DB_PASS","")
+PORTAL_DB_NAME = os.environ.get("PORTAL_DB_NAME","falcon_portal")
 
 # alarm database
 # TODO: read from api instead of db
-ALARM_DB_HOST = "127.0.0.1"
-ALARM_DB_PORT = 3306
-ALARM_DB_USER = "root"
-ALARM_DB_PASS = ""
-ALARM_DB_NAME = "alarms"
+ALARM_DB_HOST = os.environ.get("ALARM_DB_HOST","127.0.0.1")
+ALARM_DB_PORT = int(os.environ.get("ALARM_DB_PORT",3306))
+ALARM_DB_USER = os.environ.get("ALARM_DB_USER","root")
+ALARM_DB_PASS = os.environ.get("ALARM_DB_PASS","")
+ALARM_DB_NAME = os.environ.get("ALARM_DB_NAME","alarms")
 
 # ldap config
-LDAP_ENABLED = False
-LDAP_SERVER = "ldap.forumsys.com:389"
-LDAP_BASE_DN = "dc=example,dc=com"
-LDAP_BINDDN_FMT = "uid=%s,dc=example,dc=com"
-LDAP_SEARCH_FMT = "uid=%s"
+LDAP_ENABLED = os.environ.get("LDAP_ENABLED",False)
+LDAP_SERVER = os.environ.get("LDAP_SERVER","ldap.forumsys.com:389")
+LDAP_BASE_DN = os.environ.get("LDAP_BASE_DN","dc=example,dc=com")
+LDAP_BINDDN_FMT = os.environ.get("LDAP_BINDDN_FMT","uid=%s,dc=example,dc=com")
+LDAP_SEARCH_FMT = os.environ.get("LDAP_SEARCH_FMT","uid=%s")
 LDAP_ATTRS = ["cn","mail","telephoneNumber"]
 LDAP_TLS_START_TLS = False
 LDAP_TLS_CACERTDIR = ""


### PR DESCRIPTION
1. 修改config.py部分参数可以从环境变量获取
2. 增加Dockerfile文件
```shell
# 构建镜像
#在`dashboard`目录下执行如下命令:
docker build -t falcon-dashboard:v1.0 .
# 从镜像运行容器
docker run -itd --name aaa --net host \
	-e API_ADDR=http://127.0.0.1:8080/api/v1 \
	-e PORTAL_DB_HOST=127.0.0.1 \
	-e PORTAL_DB_PORT=3306 \
	-e PORTAL_DB_USER=root \
	-e PORTAL_DB_PASS=123456 \
  	-e PORTAL_DB_NAME=falcon_portal \
    	-e ALARM_DB_PASS=123456 \
	-e ALARM_DB_HOST=127.0.0.1 \
	-e ALARM_DB_PORT=3306 \
	-e ALARM_DB_USER=root \
	-e ALARM_DB_PASS=123456 \
      	-e ALARM_DB_NAME=alarms \
	falcon-dashboard:v1.0
```