### PR TITLE
fix(falcon-plus.issue.93): return 404 when add aggregator rule

### DIFF
--- a/rrd/static/js/portal.js
+++ b/rrd/static/js/portal.js
@@ -545,7 +545,7 @@ function create_cluster_monitor_metric(grp_id) {
         'step': $("#step").val()
     }, function (json) {
         handle_quietly(json, function () {
-            location.href = "/group/" + grp_id + "/cluster";
+            location.href = "/portal/group/" + grp_id + "/cluster";
         });
     }, "json")
 }


### PR DESCRIPTION
修复 hostgroup新增 aggregator 后跳转页面404 的问题