### PR TITLE
fix "gunicorn error 104 Connection reset by peer"

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10.1
 Flask-Babel==0.9
 Jinja2==2.7.2
 Werkzeug==0.9.4
-gunicorn==18.0
+gunicorn==19.1.1
 python-dateutil==2.2
 requests==2.3.0
 mysql-python


### PR DESCRIPTION
error: [Errno 104] Connection reset by peer

```
  File "/home/falcon/dashboard-0.2.0/env/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 93, in handle
    self.handle_request(listener, req, client, addr)
  File "/home/falcon/dashboard-0.2.0/env/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 137, in handle_request
    resp.write(item)
  File "/home/falcon/dashboard-0.2.0/env/lib/python2.7/site-packages/gunicorn/http/wsgi.py", line 292, in write
    self.send_headers()
  File "/home/falcon/dashboard-0.2.0/env/lib/python2.7/site-packages/gunicorn/http/wsgi.py", line 288, in send_headers
    util.write(self.sock, util.to_bytestring(header_str))
  File "/home/falcon/dashboard-0.2.0/env/lib/python2.7/site-packages/gunicorn/util.py", line 298, in write
    sock.sendall(data)
  File "/usr/local/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 104] Connection reset by peer
```

https://github.com/benoitc/gunicorn/issues/630