### PR TITLE
fix #408, 修复dashboard graph中求和曲线中断问题

### DIFF
--- a/rrd/view/dashboard/chart.py
+++ b/rrd/view/dashboard/chart.py
@@ -112,6 +112,8 @@ def multi_endpoints_chart_data():
         max_size = 0
         for serie in series:
             serie_vs = [x[1] for x in serie["data"]]
+            if (max_size == 0 and serie_vs.count(None) > 50) or (max_size !=0 and serie_vs.count(None) >= max_size):
+                continue
             if len(serie_vs) > max_size:
                 max_size = len(serie_vs)
                 tmp_ts = [x[0] for x in serie["data"]]
@@ -188,6 +190,8 @@ def multi_counters_chart_data():
         max_size = 0
         for serie in series:
             serie_vs = [x[1] for x in serie["data"]]
+            if (max_size == 0 and serie_vs.count(None) > 50) or (max_size !=0 and serie_vs.count(None) >= max_size):
+                continue
             if len(serie_vs) > max_size:
                 max_size = len(serie_vs)
                 tmp_ts = [x[0] for x in serie["data"]]
@@ -262,6 +266,8 @@ def multi_chart_data():
         max_size = 0
         for serie in series:
             serie_vs = [x[1] for x in serie["data"]]
+            if (max_size == 0 and serie_vs.count(None) > 50) or (max_size !=0 and serie_vs.count(None) >= max_size):
+                continue
             if len(serie_vs) > max_size:
                 max_size = len(serie_vs)
                 tmp_ts = [x[0] for x in serie["data"]]


### PR DESCRIPTION
fix #408, 修复dashboard graph中求和曲线中断问题

求和曲线中断的原因是在时间跨度比较长时，NaN的值是每分钟一个点，而正常的值可能是5分钟或者其他大于一分钟的时间间隔一个点，导致列表求和结果的时间序列错误。

Signed-off-by: yul <yul@inke.cn>