### PR TITLE
Docker无法 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ yum groupinstall -y "Development tools"
 RUN export HOME=/home/work/ && mkdir -p $HOME/open-falcon/dashboard && cd $HOME/open-falcon/dashboard
 WORKDIR /home/work/open-falcon/dashboard
 ADD ./ ./
-RUN virtualenv ./env && ./env/bin/pip install -r pip_requirements.txt -i http://pypi.douban.com/simple
+RUN virtualenv ./env && ./env/bin/pip install -r pip_requirements.txt -i https://pypi.douban.com/simple
 
 ADD ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
出问题的地方
RUN virtualenv ./env && ./env/bin/pip install -r pip_requirements.txt -i http://pypi.douban.com/simple
```
  The repository located at pypi.douban.com is not a trusted or secure host and is being ignored. If this repository is available via HTTPS it is recommended to use HTTPS instead, otherwise you may silence this warning and allow it anyways with '--trusted-host pypi.douban.com'.
  Could not find a version that satisfies the requirement Flask==0.10.1 (from -r pip_requirements.txt (line 1)) (from versions: )
No matching distribution found for Flask==0.10.1 (from -r pip_requirements.txt (line 1))
You are using pip version 9.0.1, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```
修改
-> http -> https
 https://pypi.douban.com/simple
自测成功