### PR TITLE
fix bugs: hostgroup添加hosts时未处理前后空格

### DIFF
--- a/rrd/view/portal/host.py
+++ b/rrd/view/portal/host.py
@@ -123,7 +123,7 @@ def host_add_post():
         return jsonify(msg='hosts is blank')
 
     host_arr = hosts.splitlines()
-    safe_host_arr = [h for h in host_arr if h]
+    safe_host_arr = [h.strip() for h in host_arr if h]
     if not safe_host_arr:
         return jsonify(msg='hosts is blank')
 


### PR DESCRIPTION
问题：添加多条hosts时，只处理了整个文本的前后空格，未处理每个hostname前后空格，所以数据入库时hostname前后带空格，但是hostgroup在展示host列表时会预先处理hostname前后空格，导致用户无法发现数据的不一致性

影响：nodata、aggregator等服务使用接口获取主机列表之后无法找到相应的监控数据

解决：将hosts入库前处理掉每个hostname前后空格