### PR TITLE
fix(screen/team/user): strip space when add or edit data

### DIFF
--- a/rrd/view/auth/auth.py
+++ b/rrd/view/auth/auth.py
@@ -98,9 +98,9 @@ def auth_register():
     if request.method == "POST":
         ret = {"msg":""}
 
-        name = request.form.get("name", "")
-        cnname = request.form.get("cnname", "")
-        email = request.form.get("email", "")
+        name = request.form.get("name", "").strip()
+        cnname = request.form.get("cnname", "").strip()
+        email = request.form.get("email", "").strip()
         password = request.form.get("password", "")
         repeat_password = request.form.get("repeat_password", "")
 

--- a/rrd/view/dashboard/screen.py
+++ b/rrd/view/dashboard/screen.py
@@ -52,7 +52,7 @@ def dash_screen_edit(sid):
         abort(404, "no such screen")
 
     if request.method == "POST":
-        screen_name = request.form.get("screen_name")
+        screen_name = request.form.get("screen_name").strip()
         screen.update(name=screen_name)
         return redirect("/screen/%s" %screen.id)
     else:
@@ -65,7 +65,7 @@ def dash_screen_clone(sid):
         abort(404, "no such screen")
 
     if request.method == "POST":
-        screen_name = request.form.get("screen_name")
+        screen_name = request.form.get("screen_name").strip()
         with_graph = request.form.get("with_graph")
 
         new_s = DashboardScreen.add(screen.pid, screen_name)
@@ -147,7 +147,7 @@ def dash_screen_embed(sid):
 @app.route("/screen/add", methods=["GET", "POST"])
 def dash_screen_add():
     if request.method == "POST":
-        name = request.form.get("screen_name")
+        name = request.form.get("screen_name").strip()
         pid = request.form.get("pid", '0')
         screen = DashboardScreen.add(pid, name)
         return redirect("/screen/%s" % screen.id)
@@ -173,7 +173,7 @@ def dash_graph_add(sid):
     pscreen = DashboardScreen.get(screen.pid)
 
     if request.method == "POST":
-        title = request.form.get("title")
+        title = request.form.get("title").strip()
 
         hosts = request.form.get("hosts", "").strip()
         hosts = hosts and hosts.split("\n") or []

--- a/rrd/view/team/team.py
+++ b/rrd/view/team/team.py
@@ -53,8 +53,8 @@ def team_create():
     if request.method == "POST":
         ret = {"msg":""}
 
-        name = request.form.get("name", "")
-        resume = request.form.get("resume", "")
+        name = request.form.get("name", "").strip()
+        resume = request.form.get("resume", "").strip()
         users = request.form.get("users", "")
 
         user_ids = users and users.split(",") or []
@@ -82,7 +82,7 @@ def team_edit(team_id):
     if request.method == "POST":
         ret = {"msg":""}
 
-        resume = request.form.get("resume", "")
+        resume = request.form.get("resume", "").strip()
         users = request.form.get("users", "")
 
         user_ids = users and users.split(",") or []

--- a/rrd/view/user/user.py
+++ b/rrd/view/user/user.py
@@ -42,11 +42,11 @@ def user_profile():
     if request.method == "POST":
         ret = {"msg":""}
 
-        cnname = request.form.get("cnname", "")
-        email = request.form.get("email", "")
-        im = request.form.get("im", "")
-        phone = request.form.get("phone", "")
-        qq = request.form.get("qq", "")
+        cnname = request.form.get("cnname", "").strip()
+        email = request.form.get("email", "").strip()
+        im = request.form.get("im", "").strip()
+        phone = request.form.get("phone", "").strip()
+        qq = request.form.get("qq", "").strip()
 
         d = {
                 "cnname": cnname,
@@ -121,13 +121,13 @@ def user_create():
     if request.method == "POST":
         ret = {"msg":""}
 
-        name = request.form.get("name", "")
-        cnname = request.form.get("cnname", "")
+        name = request.form.get("name", "").strip()
+        cnname = request.form.get("cnname", "").strip()
         password = request.form.get("password", "")
-        email = request.form.get("email", "")
-        phone = request.form.get("phone", "")
-        im = request.form.get("im", "")
-        qq = request.form.get("qq", "")
+        email = request.form.get("email", "").strip()
+        phone = request.form.get("phone", "").strip()
+        im = request.form.get("im", "").strip()
+        qq = request.form.get("qq", "").strip()
 
         if not name or not cnname or not password or not email:
             ret["msg"] = "not all form item entered"
@@ -161,11 +161,11 @@ def admin_user_edit(user_id):
             return json.dumps(ret)
 
         user_id = request.form.get("id", "")
-        cnname = request.form.get("cnname", "")
-        email = request.form.get("email", "")
-        phone = request.form.get("phone", "")
-        im = request.form.get("im", "")
-        qq = request.form.get("qq", "")
+        cnname = request.form.get("cnname", "").strip()
+        email = request.form.get("email", "").strip()
+        phone = request.form.get("phone", "").strip()
+        im = request.form.get("im", "").strip()
+        qq = request.form.get("qq", "").strip()
 
         d = {
             "user_id": int(user_id), "cnname": cnname, "email": email, "phone": phone, "im": im, "qq": qq,


### PR DESCRIPTION
继前两天修复hostgroup批量添加host问题之后，翻了下user、screen、team、profile相关数据的创建和编辑操作也存在未处理数据前后空格的问题，现一并给修正了