### PR TITLE
update Werkzeug version

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.0
 Flask-Babel==0.9
 Jinja2>=2.10.1
-Werkzeug==0.15.3
+Werkzeug==0.15.4
 gunicorn==19.9.0
 python-dateutil==2.2
 requests==2.3.0


### PR DESCRIPTION
updated  Werkzeug to 0.15.4.Fix error.
```python
  File "/home/dashboard/wsgi.py", line 28, in <module>
    from rrd import app
  File "/home/dashboard/rrd/__init__.py", line 19, in <module>
    from flask import Flask, request
  File "/home/dashboard/env/lib/python2.7/site-packages/flask/__init__.py", line 21, in <module>
    from .app import Flask, Request, Response
  File "/home/dashboard/env/lib/python2.7/site-packages/flask/app.py", line 23, in <module>
    from werkzeug.routing import BuildError, Map, RequestRedirect, Rule
SyntaxError: unqualified exec is not allowed in function '_compile_builder' it contains a nested function with free variables (routing.py, line 948)
```